### PR TITLE
feat: append commit hash to beta/alpha JAR filenames after build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,6 +28,23 @@ jobs:
         run: chmod +x ./gradlew
       - name: Build
         run: ./gradlew build shadowJar
+      - name: Rename JARs if beta or alpha
+        run: |
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+
+          for dir in bukkit folia velocity; do
+            for file in "$dir"/build/libs/*.jar; do
+              filename=$(basename "$file")
+              if [[ "$filename" =~ [Bb][Ee][Tt][Aa] || "$filename" =~ [Aa][Ll][Pp][Hh][Aa] ]]; then
+                base="${filename%.jar}"
+                newname="${base}-${COMMIT_HASH}.jar"
+                mv "$file" "$dir/build/libs/$newname"
+                echo "Renamed $filename to $newname"
+              else
+                echo "No beta/alpha in $filename, skipping."
+              fi
+            done
+          done
       - name: capture build artifacts (spigot)
         uses: actions/upload-artifact@v4.6.0
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,14 +28,14 @@ jobs:
         run: chmod +x ./gradlew
       - name: Build
         run: ./gradlew build shadowJar
-      - name: Rename JARs if beta or alpha
+      - name: Rename JARs if alpha
         run: |
           COMMIT_HASH=$(git rev-parse --short HEAD)
 
           for dir in bukkit folia velocity; do
             for file in "$dir"/build/libs/*.jar; do
               filename=$(basename "$file")
-              if [[ "$filename" =~ [Bb][Ee][Tt][Aa] || "$filename" =~ [Aa][Ll][Pp][Hh][Aa] ]]; then
+              if [[ "$filename" =~ [Aa][Ll][Pp][Hh][Aa] ]]; then
                 base="${filename%.jar}"
                 newname="${base}-${COMMIT_HASH}.jar"
                 mv "$file" "$dir/build/libs/$newname"


### PR DESCRIPTION
- 在构建完成后，自动检测 JAR 文件名是否包含 "beta" 或 "alpha"（不区分大小写）
- 若匹配，则在文件名中追加当前提交的短哈希（例如：plugin-beta-a1b2c3d.jar）
- 适用于 bukkit、folia 和 velocity 模块
- 避免上传含有模糊版本信息的构建产物，便于追溯构建来源