### PR TITLE
ci: add GitHub Actions workflow to build and upload JARs on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release Build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: Build
+        run: ./gradlew build shadowJar
+
+      - name: Rename if beta/alpha
+        run: |
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+
+          for dir in bukkit folia velocity; do
+            for file in "$dir"/build/libs/*-all.jar; do
+              filename=$(basename "$file")
+              if [[ "$filename" =~ [Bb][Ee][Tt][Aa] || "$filename" =~ [Aa][Ll][Pp][Hh][Aa] ]]; then
+                base="${filename%.jar}"
+                newname="${base}-${COMMIT_HASH}.jar"
+                mv "$file" "$dir/build/libs/$newname"
+              fi
+            done
+          done
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            bukkit/build/libs/*-all*.jar
+            folia/build/libs/*-all*.jar
+            velocity/build/libs/*-all*.jar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- 新增 release.yml，在推送 tag 时自动构建项目
- 仅上传包含 -all 的 JAR 文件到对应的 GitHub Release
- 若文件名包含 beta 或 alpha，则在 .jar 前附加当前提交的短哈希
- 支持多模块（bukkit, folia, velocity）的构建与上传
- 不生成 zip，仅上传 JAR 构建产物