### PR TITLE
fix(command): Fix and enhance /aqqbot send subcommand

### DIFF
--- a/common/src/main/kotlin/top/alazeprt/aqqbot/command/AParentCommand.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/command/AParentCommand.kt
@@ -32,7 +32,6 @@ class AParentCommand(val plugin: AQQBot) : ACommand {
             1 -> listOf("whitelist", "status", "help", "reload", "send")
             2 -> return when (args[0]) {
                 "whitelist" -> listOf("bind", "unbind", "reset", "query", "info")
-                "send" -> listOf("<groupId>")
                 else -> emptyList()
             }
             3 -> return when (args[0]) {
@@ -43,7 +42,6 @@ class AParentCommand(val plugin: AQQBot) : ACommand {
                     "reset" -> listOf("qq", "player")
                     else -> emptyList()
                 }
-                "send" -> listOf("<message>")
                 else -> emptyList()
             }
             else -> emptyList()

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/command/AParentCommand.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/command/AParentCommand.kt
@@ -11,6 +11,7 @@ class AParentCommand(val plugin: AQQBot) : ACommand {
             SubHelp(plugin).onCommand(command, sender, args)
         } else when (args[0]) {
             "status" -> SubStatus(plugin).onCommand(command, sender, args)
+            "send" -> SubSend(plugin).onCommand(command, sender, args)
             "whitelist" -> if (args.size == 1) {
                 SubHelp(plugin).onCommand(command, sender, args)
             } else when (args[1]) {
@@ -28,9 +29,10 @@ class AParentCommand(val plugin: AQQBot) : ACommand {
 
     override fun onComplete(args: List<String>): List<String> {
         return when (args.size) {
-            1 -> listOf("whitelist", "status", "help", "reload")
+            1 -> listOf("whitelist", "status", "help", "reload", "send")
             2 -> return when (args[0]) {
                 "whitelist" -> listOf("bind", "unbind", "reset", "query", "info")
+                "send" -> listOf("<groupId>")
                 else -> emptyList()
             }
             3 -> return when (args[0]) {
@@ -41,6 +43,7 @@ class AParentCommand(val plugin: AQQBot) : ACommand {
                     "reset" -> listOf("qq", "player")
                     else -> emptyList()
                 }
+                "send" -> listOf("<message>")
                 else -> emptyList()
             }
             else -> emptyList()

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/command/sub/SubSend.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/command/sub/SubSend.kt
@@ -7,8 +7,10 @@ import top.alazeprt.aqqbot.AQQBot
 import top.alazeprt.aqqbot.bot.BotProvider
 import top.alazeprt.aqqbot.command.ACommand
 import top.alazeprt.aqqbot.profile.ASender
+import top.alazeprt.aqqbot.util.AFormatter
 
 class SubSend(val plugin: AQQBot): ACommand {
+
     override fun onCommand(
         command: String,
         sender: ASender,
@@ -18,18 +20,29 @@ class SubSend(val plugin: AQQBot): ACommand {
             sender.sendMessage(Component.text("你没有权限使用该命令!", NamedTextColor.RED))
             return
         }
-        if (args.size != 3) {
-            sender.sendMessage(Component.text("用法: /aqqbot send <群号> <消息>"))
+        if (args.size < 3) {
+            val usageMessage = plugin.messageManager.get("game.send.usage", null)
+            sender.sendMessage(AFormatter.pluginToChat(usageMessage))
             return
         }
         val groupId = try {
             args[1].toLong()
         } catch (e: NumberFormatException) {
-            sender.sendMessage(Component.text("无效的群号: ${args[1]}", NamedTextColor.RED))
+            val invalidIdMessage = plugin.messageManager.get(
+                "game.send.invalid_group_id",
+                mapOf("group_id" to args[1]),
+                null
+            )
+            sender.sendMessage(AFormatter.pluginToChat(invalidIdMessage))
             return
         }
         val message = args.drop(2).joinToString(" ")
         BotProvider.getBot()!!.action(SendGroupMessage(groupId, message))
-        sender.sendMessage(Component.text("消息已发送到群 $groupId", NamedTextColor.GREEN))
-    }
+
+        val successMessage = plugin.messageManager.get(
+            "game.send.success",
+            mapOf("group_id" to groupId.toString()),
+            null
+        )
+        sender.sendMessage(AFormatter.pluginToChat(successMessage))    }
 }

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/command/sub/SubSend.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/command/sub/SubSend.kt
@@ -30,7 +30,7 @@ class SubSend(val plugin: AQQBot): ACommand {
         } catch (e: NumberFormatException) {
             val invalidIdMessage = plugin.messageManager.get(
                 "game.send.invalid_group_id",
-                mapOf("group_id" to args[1]),
+                mapOf("groupId" to args[1]),
                 null
             )
             sender.sendMessage(AFormatter.pluginToChat(invalidIdMessage))
@@ -41,7 +41,7 @@ class SubSend(val plugin: AQQBot): ACommand {
 
         val successMessage = plugin.messageManager.get(
             "game.send.success",
-            mapOf("group_id" to groupId.toString()),
+            mapOf("groupId" to groupId.toString()),
             null
         )
         sender.sendMessage(AFormatter.pluginToChat(successMessage))    }

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/command/sub/SubSend.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/command/sub/SubSend.kt
@@ -22,8 +22,13 @@ class SubSend(val plugin: AQQBot): ACommand {
             sender.sendMessage(Component.text("用法: /aqqbot send <群号> <消息>"))
             return
         }
-        val groupId = args[1].toLong()
-        val message = args[2]
+        val groupId = try {
+            args[1].toLong()
+        } catch (e: NumberFormatException) {
+            sender.sendMessage(Component.text("无效的群号: ${args[1]}", NamedTextColor.RED))
+            return
+        }
+        val message = args.drop(2).joinToString(" ")
         BotProvider.getBot()!!.action(SendGroupMessage(groupId, message))
         sender.sendMessage(Component.text("消息已发送到群 $groupId", NamedTextColor.GREEN))
     }

--- a/common/src/main/resources/messages.yml
+++ b/common/src/main/resources/messages.yml
@@ -55,6 +55,10 @@ game:
   successfully_reset: "&b[AQQBot] 重置成功!"
   bind_too_many_accounts: "&c[AQQBot] ${userId} 的账号已经不能再绑定更多账户了!"
   already_exists: "&c[AQQBot] ${playerName} 已经被 ${anotherUserId} 占用了!"
+  send:
+    usage: "&e[AQQBot] 用法: /aqqbot send <群号> <消息>"
+    invalid_group_id: "&c[AQQBot] 非法的群号: ${group_id}"
+    success: "&a[AQQBot] 消息已成功发送至群 ${group_id}"
   query_result:
     - "&a[AQQBot] 查询结果: "
     - "&bQQ号: ${userId}"

--- a/common/src/main/resources/messages.yml
+++ b/common/src/main/resources/messages.yml
@@ -57,8 +57,8 @@ game:
   already_exists: "&c[AQQBot] ${playerName} 已经被 ${anotherUserId} 占用了!"
   send:
     usage: "&e[AQQBot] 用法: /aqqbot send <群号> <消息>"
-    invalid_group_id: "&c[AQQBot] 非法的群号: ${group_id}"
-    success: "&a[AQQBot] 消息已成功发送至群 ${group_id}"
+    invalid_group_id: "&c[AQQBot] 非法的群号: ${groupId}"
+    success: "&a[AQQBot] 消息已成功发送至群 ${groupId}"
   query_result:
     - "&a[AQQBot] 查询结果: "
     - "&bQQ号: ${userId}"


### PR DESCRIPTION
This commit comprehensively fixes and enhances the `/aqqbot send` subcommand to make it fully functional and user-friendly.

- Fix: The command now correctly handles multi-word messages by properly parsing and joining arguments, resolving the critical bug where messages with spaces would fail.

- Feat: Added robust error handling. It now validates the group ID to prevent `NumberFormatException`